### PR TITLE
Revert "Install node using the script from official source and then apt-get"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,9 @@ ENV LANG en_GB.UTF-8
 ENV LANGUAGE en_GB:en
 ENV LC_ALL en_GB.UTF-8
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 
-RUN apt-get install -y google-cloud-sdk nodejs
+RUN apt-get install -y google-cloud-sdk \
+  nodejs
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Reverts flexys/docker-protractor#5